### PR TITLE
#100: Устранено дублирование записей в списке операций

### DIFF
--- a/lawe/tests/testOperationsView.py
+++ b/lawe/tests/testOperationsView.py
@@ -203,3 +203,15 @@ class TestOperationsView(TestOperations):
 		# Then
 		root = self.parse(response)
 		self.assertEqual(len(root.findall(".//operation")), 100)
+
+	def testEachOperationShownOnlyOnce(self):
+		''' После выкатки возникла ошибка, что данные операций дублируются '''
+		# Given
+		nu = User.objects.create_user('new', 'new')
+		self.a2.allow_users.add(nu)
+		Transaction.objects.create(debit=self.a1, credit=self.a2, amount=42)
+		# When
+		response = self.client.get('/')
+		# Then
+		root = self.parse(response)
+		self.assertEqual(len(root.findall(".//operation")), 1)

--- a/lawe/views/OperationView.py
+++ b/lawe/views/OperationView.py
@@ -63,7 +63,7 @@ class OperationView(LoginRequiredMixin, TemplateView):
 			Transaction.objects.filter(
 				Q(debit__allow_users__id=self.request.user.id) |
 				Q(credit__allow_users__id=self.request.user.id)
-			).order_by('-opdate', '-date'),
+			).distinct().order_by('-opdate', '-date'),
 			100
 		)
 		context['operations'] = [self.get_operation_data(op) for op in operations.page(1)]


### PR DESCRIPTION
Это происходило, когда несколько юзеров имели доступ к используемым счетам.
Данные дублировались.